### PR TITLE
Add typed list operations and refactor core modules

### DIFF
--- a/docs/for-ide/BUILD.md
+++ b/docs/for-ide/BUILD.md
@@ -38,6 +38,22 @@ Useful target sets:
 2. Full compiler + IDE: `cmake --build build-codex --target styio styio_lspd -j4`
 3. IDE tests only: `cmake --build build-codex --target styio_ide_test -j4`
 
+## Prune Old Build Directories
+
+Preview which build directories would be removed while keeping the newest three:
+
+```bash
+scripts/cleanup-builds.sh
+```
+
+Apply the cleanup:
+
+```bash
+scripts/cleanup-builds.sh --apply
+```
+
+The script only touches repo-root directories named `build` or `build-*`, and sorts them by modification time.
+
 ## Run The LSP Daemon
 
 ```bash

--- a/scripts/cleanup-builds.sh
+++ b/scripts/cleanup-builds.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/cleanup-builds.sh [options]
+
+Options:
+  --keep <count>  Keep the newest <count> build directories (default: 3)
+  --apply         Delete old build directories. Without this flag, only print a dry run.
+  -h, --help      Show this help
+
+Notes:
+  - Matches build directories in the repo root named "build" or "build-*".
+  - Sorts by directory modification time, newest first.
+USAGE
+}
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+KEEP=3
+APPLY=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --keep)
+      if [[ $# -lt 2 ]]; then
+        echo "$0: --keep requires a value" >&2
+        exit 2
+      fi
+      KEEP="$2"
+      shift 2
+      ;;
+    --apply)
+      APPLY=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if ! [[ "$KEEP" =~ ^[0-9]+$ ]] || [[ "$KEEP" -lt 1 ]]; then
+  echo "$0: --keep must be a positive integer" >&2
+  exit 2
+fi
+
+stat_mtime() {
+  local path="$1"
+
+  if stat -f '%m' "$path" >/dev/null 2>&1; then
+    stat -f '%m' "$path"
+    return 0
+  fi
+
+  stat -c '%Y' "$path"
+}
+
+format_mtime() {
+  local epoch="$1"
+
+  if date -r "$epoch" '+%Y-%m-%d %H:%M:%S' >/dev/null 2>&1; then
+    date -r "$epoch" '+%Y-%m-%d %H:%M:%S'
+    return 0
+  fi
+
+  date -d "@$epoch" '+%Y-%m-%d %H:%M:%S'
+}
+
+dir_size() {
+  local path="$1"
+  du -sh "$path" 2>/dev/null | awk '{print $1}'
+}
+
+declare -a entries=()
+while IFS= read -r -d '' dir; do
+  rel="${dir#$ROOT/}"
+  entries+=("$(stat_mtime "$dir")"$'\t'"$rel")
+done < <(find "$ROOT" -mindepth 1 -maxdepth 1 -type d \( -name 'build' -o -name 'build-*' \) -print0)
+
+if [[ ${#entries[@]} -eq 0 ]]; then
+  echo "[cleanup-builds] no build directories found under $ROOT"
+  exit 0
+fi
+
+declare -a sorted=()
+while IFS= read -r line; do
+  sorted+=("$line")
+done < <(printf '%s\n' "${entries[@]}" | sort -t $'\t' -k1,1nr -k2,2)
+
+echo "[cleanup-builds] repo root: $ROOT"
+echo "[cleanup-builds] keep newest: $KEEP"
+echo "[cleanup-builds] mode: $([[ "$APPLY" -eq 1 ]] && echo apply || echo dry-run)"
+echo
+
+declare -a remove_dirs=()
+for i in "${!sorted[@]}"; do
+  line="${sorted[$i]}"
+  epoch="${line%%$'\t'*}"
+  rel="${line#*$'\t'}"
+  abs="$ROOT/$rel"
+  size="$(dir_size "$abs")"
+  label="KEEP"
+
+  if (( i >= KEEP )); then
+    label="REMOVE"
+    remove_dirs+=("$abs")
+  fi
+
+  printf '[cleanup-builds] %-6s %s  %8s  %s\n' \
+    "$label" \
+    "$(format_mtime "$epoch")" \
+    "$size" \
+    "$rel"
+done
+
+if [[ ${#remove_dirs[@]} -eq 0 ]]; then
+  echo
+  echo "[cleanup-builds] nothing to delete"
+  exit 0
+fi
+
+if [[ "$APPLY" -ne 1 ]]; then
+  echo
+  echo "[cleanup-builds] dry run only; re-run with --apply to delete old build directories"
+  exit 0
+fi
+
+echo
+for dir in "${remove_dirs[@]}"; do
+  echo "[cleanup-builds] deleting ${dir#$ROOT/}"
+  rm -rf -- "$dir"
+done
+
+echo "[cleanup-builds] cleanup complete"


### PR DESCRIPTION
This pull request introduces a new utility script to help manage build directories and updates the documentation to explain its usage. The main addition is a script that finds and removes old build directories, keeping only the most recent ones, which helps save disk space and keep the repository tidy.

**Documentation updates:**

* Added a section to `docs/for-ide/BUILD.md` describing how to preview and apply cleanup of old build directories using the new `scripts/cleanup-builds.sh` script. The documentation explains that the script keeps the newest three build directories by default and only affects directories named `build` or `build-*` in the repository root.

**New utility script:**

* Added `scripts/cleanup-builds.sh`, a Bash script that:
  * Lists or deletes old build directories in the repository root, keeping the newest N (default: 3).
  * Supports a dry-run mode (default) and an `--apply` flag to actually perform deletions.
  * Provides options for customizing how many directories to keep and includes user-friendly output.
  * Handles cross-platform differences in stat/date commands for modification time formatting.
  * Includes usage/help output and robust argument parsing.